### PR TITLE
NN-653 Auto allocation process allocating all offenders to one KW

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerAutoAllocationService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerAutoAllocationService.java
@@ -156,9 +156,8 @@ public class KeyworkerAutoAllocationService {
         storeAllocation(offender, keyworker);
 
         // Update Key worker pool with refreshed Key worker (following successful allocation)
-        KeyworkerDto refreshedKeyworker = keyworkerService.getKeyworkerDetails(offender.getAgencyId(), keyworker.getStaffId());
 
-        keyworkerPool.refreshKeyworker(refreshedKeyworker);
+        keyworkerPool.incrementAndRefreshKeyworker(keyworker); //refreshedKeyworker);
     }
 
     private List<OffenderLocationDto> getUnallocatedOffenders(String prisonId) {

--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerPool.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerPool.java
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.keyworker.exception.AllocationException;
 import uk.gov.justice.digital.hmpps.keyworker.model.OffenderKeyworker;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -144,7 +143,7 @@ public class KeyworkerPool {
     /**
      * Identifies and returns Key worker to whom offender should be allocated, as determined by allocation rules. Note
      * that if the returned Key worker is used for allocation of an offender, the pool must be updated with refreshed
-     * Key worker details (via {@link #refreshKeyworker(KeyworkerDto)}).
+     * Key worker details (via {@link #incrementAndRefreshKeyworker(KeyworkerDto)}).
      *
      * @param offenderNo offender number of offender for whom key worker allocation is required.
      * @return the priority {@code Keyworker}.
@@ -184,13 +183,14 @@ public class KeyworkerPool {
     }
 
     /**
-     * Refreshes pool with provided Key worker. If provided Key worker does not already exist in the pool, an
-     * {@code IllegalStateException} is throwm.
+     * Increments allocation count of provided Key worker and Refreshes pool (to recalculate its position in pool).
+     * If provided Key worker does not already exist in the pool, an
+     * {@code IllegalStateException} is thrown.
      *
-     * @param keyworker Key worker to refresh.
+     * @param keyworker Key worker to process.
      * @throws IllegalStateException if Key worker is not already present in the pool.
      */
-    public void refreshKeyworker(KeyworkerDto keyworker) {
+    public void incrementAndRefreshKeyworker(KeyworkerDto keyworker) {
         Validate.notNull(keyworker, "Key worker to refresh must be specified.");
 
         // Remove Key worker from pool (throwing exception if Key worker not in pool)
@@ -199,6 +199,7 @@ public class KeyworkerPool {
 
             throw new IllegalStateException("Key worker to refresh is not in Key worker pool.");
         }
+        keyworker.setNumberAllocated(keyworker.getNumberAllocated() + 1);
 
         // Add Key worker back to pool
         reinstateKeyworker(keyworker, null);

--- a/src/test/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerPoolTest.java
+++ b/src/test/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerPoolTest.java
@@ -279,17 +279,17 @@ public class KeyworkerPoolTest {
         KeyworkerDto otherKeyworker = getKeyworker(8, 5, CAPACITY_TIER_1);
 
         // Attempt refresh
-        keyworkerPool.refreshKeyworker(otherKeyworker);
+        keyworkerPool.incrementAndRefreshKeyworker(otherKeyworker);
     }
 
     // Given a KW is in the KWP
-    // When attempt is made to refresh KW in the KWP
-    // Then attempt is successful and KWP is updated with refreshed KW
+    // When attempt is made to increment the KW's allocations
+    // Then attempt is successful and KWP is updated with KW in new position in pool
     //
     // If this test fails, a KW who is a member of the KWP may not be refreshed correctly in KWP and this may result in
     // incorrect allocations taking place for the KW due to KWP having an out-of-date KW entry.
     @Test
-    public void testKeyworkerRefreshedWhentMemberOfKeyworkerPool() {
+    public void testKeyworkerRefreshedWhenMemberOfKeyworkerPool() {
         // KWP initialised with an initial set of KWs
         final int lowAllocCount = 1;
         final int highAllocCount = FULLY_ALLOCATED - 1;
@@ -298,28 +298,25 @@ public class KeyworkerPoolTest {
         List<KeyworkerDto> keyworkers = getKeyworkers(5, lowAllocCount, highAllocCount, CAPACITY_TIER_1);
 
         // Add another couple of KWs with known allocation counts (one high, one low)
-        KeyworkerDto lowAllocKeyworker = getKeyworker(refreshKeyworkerStaffId - 1, lowAllocCount, CAPACITY_TIER_1);
-        KeyworkerDto highAllocKeyworker = getKeyworker(refreshKeyworkerStaffId, highAllocCount, CAPACITY_TIER_1);
+        KeyworkerDto firstKeyworker = getKeyworker(refreshKeyworkerStaffId - 1, 0, CAPACITY_TIER_1);
+        KeyworkerDto secondKeyworker = getKeyworker(refreshKeyworkerStaffId, 0, CAPACITY_TIER_1);
 
-        keyworkers.add(lowAllocKeyworker);
-        keyworkers.add(highAllocKeyworker);
+        keyworkers.add(firstKeyworker);
+        keyworkers.add(secondKeyworker);
 
         keyworkerPool = initKeyworkerPool(keyworkerService, keyworkers, capacityTiers);
 
-        // Verify that priority KW is not the one with known high alloc count
+        // Verify that priority KW is the one with known low alloc count and lowest staff id
         KeyworkerDto priorityKeyworker = keyworkerPool.getKeyworker("A1111AA");
 
-        assertThat(priorityKeyworker).isNotSameAs(highAllocKeyworker);
-
-        // Simulate refreshed high alloc KW (now having zero allocations).
-        KeyworkerDto refreshedHighAllocKeyworker = getKeyworker(refreshKeyworkerStaffId, 0, CAPACITY_TIER_1);
+        assertThat(priorityKeyworker).isSameAs(firstKeyworker);
 
         // Attempt refresh
-        keyworkerPool.refreshKeyworker(refreshedHighAllocKeyworker);
+        keyworkerPool.incrementAndRefreshKeyworker(firstKeyworker);
 
-        // Verify that priority KW is our refreshed high-alloc Key worker (that now has zero allocations)
+        // Verify that priority KW is now the second one (that still has zero allocations)
         priorityKeyworker = keyworkerPool.getKeyworker("A2222AA");
 
-        assertThat(priorityKeyworker).isSameAs(refreshedHighAllocKeyworker);
+        assertThat(priorityKeyworker).isSameAs(secondKeyworker);
     }
 }


### PR DESCRIPTION
Problem was that when refreshing a KW after an allocation, the KW details call was ignoring Provisional allocations!

Solution was to not use a db (and new nomis) call but just increment the allocation count locally