### PR TITLE
NN-653 Auto allocation process is not allocating offenders to expected KW

### DIFF
--- a/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerAutoAllocationService.java
+++ b/src/main/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerAutoAllocationService.java
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.keyworker.services;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.metrics.CounterService;
 import org.springframework.boot.actuate.metrics.Metric;
 import org.springframework.boot.actuate.metrics.buffer.BufferMetricReader;
@@ -12,19 +11,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.justice.digital.hmpps.keyworker.dto.KeyworkerDto;
 import uk.gov.justice.digital.hmpps.keyworker.dto.OffenderLocationDto;
-import uk.gov.justice.digital.hmpps.keyworker.dto.PrisonerDetailDto;
 import uk.gov.justice.digital.hmpps.keyworker.exception.AllocationException;
 import uk.gov.justice.digital.hmpps.keyworker.model.AllocationReason;
 import uk.gov.justice.digital.hmpps.keyworker.model.AllocationType;
 import uk.gov.justice.digital.hmpps.keyworker.model.OffenderKeyworker;
 import uk.gov.justice.digital.hmpps.keyworker.repository.OffenderKeyworkerRepository;
 
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Service implementation of Key worker auto-allocation. On initiation the auto-allocation process will attempt to
@@ -104,7 +98,6 @@ public class KeyworkerAutoAllocationService {
             log.info("Proceeding with auto-allocation for {} unallocated offenders and {} available Key workers at agency [{}].",
                     unallocatedOffenders.size(), availableKeyworkers.size(), prisonId);
 
-            // ****** TODO calculate recently deallocated totals for all KWs
             // At this point, we have some unallocated offenders and some available Key workers. Let's put the Key
             // workers into a pool then start processing allocations.
             KeyworkerPool keyworkerPool = keyworkerPoolFactory.getKeyworkerPool(availableKeyworkers);
@@ -163,7 +156,7 @@ public class KeyworkerAutoAllocationService {
         storeAllocation(offender, keyworker);
 
         // Update Key worker pool with refreshed Key worker (following successful allocation)
-        keyworkerPool.incrementAndRefreshKeyworker(keyworker); //refreshedKeyworker);
+        keyworkerPool.incrementAndRefreshKeyworker(keyworker);
     }
 
     private List<OffenderLocationDto> getUnallocatedOffenders(String prisonId) {

--- a/src/test/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerPoolTest.java
+++ b/src/test/java/uk/gov/justice/digital/hmpps/keyworker/services/KeyworkerPoolTest.java
@@ -10,6 +10,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.justice.digital.hmpps.keyworker.dto.KeyworkerDto;
 import uk.gov.justice.digital.hmpps.keyworker.dto.PrisonerDetailDto;
 import uk.gov.justice.digital.hmpps.keyworker.exception.AllocationException;
+import uk.gov.justice.digital.hmpps.keyworker.model.AllocationType;
 import uk.gov.justice.digital.hmpps.keyworker.model.OffenderKeyworker;
 import uk.gov.justice.digital.hmpps.keyworker.repository.OffenderKeyworkerRepository;
 
@@ -56,7 +57,8 @@ public class KeyworkerPoolTest {
     // Each unit test below is preceded by acceptance criteria in Given-When-Then form
     // KW = Key worker
     // KWP = Key worker pool
-    // Capacity refers to spare allocation capacity (i.e. the KW has capacity for further offender allocations)
+    // Capacity can refer to spare allocation capacity (i.e. the KW has capacity for further offender allocations)
+    //  or total capacity
     // Allocation refers to an extant and active relationship of an offender to a Key worker
     //   (there is a distinction between an automatically created allocation and a manually created allocation)
     // For purposes of these tests, 'multiple' means at least three or more
@@ -209,10 +211,17 @@ public class KeyworkerPoolTest {
 
         OffenderKeyworker staff3Allocation =
                 getPreviousKeyworkerAutoAllocation(TEST_AGENCY_ID, "A3333AA", staffId3, refDateTime.minusDays(5));
+        OffenderKeyworker staff3IrrelevantAllocationP =
+                getPreviousKeyworkerAutoAllocation(TEST_AGENCY_ID, "A3333AB", staffId3, refDateTime.minusDays(1));
+        OffenderKeyworker staff3IrrelevantAllocationM =
+                getPreviousKeyworkerAutoAllocation(TEST_AGENCY_ID, "A3333AC", staffId3, refDateTime.minusDays(1));
+        staff3IrrelevantAllocationP.setAllocationType(AllocationType.PROVISIONAL);
+        staff3IrrelevantAllocationM.setAllocationType(AllocationType.MANUAL);
 
         when(keyworkerService.getAllocationsForKeyworker(eq(staffId1))).thenReturn(Collections.singletonList(staff1Allocation));
         when(keyworkerService.getAllocationsForKeyworker(eq(staffId2))).thenReturn(Collections.singletonList(staff2Allocation));
-        when(keyworkerService.getAllocationsForKeyworker(eq(staffId3))).thenReturn(Collections.singletonList(staff3Allocation));
+        when(keyworkerService.getAllocationsForKeyworker(eq(staffId3))).thenReturn(Arrays.asList(
+                staff3Allocation, staff3IrrelevantAllocationP, staff3IrrelevantAllocationM));
 
         // Request KW from pool for offender
         KeyworkerDto allocatedKeyworker = keyworkerPool.getKeyworker("A1111AA");


### PR DESCRIPTION
Fixes:
Provisional allocations were being considered in the test for which KW has the most recent;
the least recent was actually being tested whereas it should be the most;
in some cases the KW allocation lists held locally were being overwritten resulting in extra DB calls