### PR TITLE
Build tweaks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,9 +40,9 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/app
-      - setup_remote_docker:
-          exclusive: true
+      - setup_remote_docker
       - run:
+          name: Build container and publish to docker hub
           command: |
             jar xvf build/libs/keyworker-service-*.jar META-INF/build-info.properties
             API_VERSION=$(grep 'build.version=' META-INF/build-info.properties | awk -F= '{print $2}')

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 defaults: &defaults
-  working_directory: /tmp/circleci-keyworker-service
+  working_directory: ~/app
 
 version: 2
 jobs:
@@ -31,7 +31,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/circleci-keyworker-service/
+          at: ~/app
       - setup_remote_docker:
           exclusive: true
       - run:
@@ -82,7 +82,7 @@ jobs:
     steps:
       - checkout
       - attach_workspace:
-          at: /tmp/circleci-keyworker-service/
+          at: ~/app
       - deploy:
           name: Install elastic beanstalk CLI
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,15 @@ jobs:
       - image: circleci/openjdk:8-jdk-browsers
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - gradle-{{ checksum "build.gradle" }}
+            - gradle-
       - run: ./gradlew build
+      - save_cache:
+          paths:
+            - ~/.gradle
+          key: gradle-{{ checksum "build.gradle" }}
       - store_test_results:
           path: build/test-results
       - store_test_results:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM openjdk:8-jdk-alpine
 MAINTAINER HMPPS Digital Studio <info@digital.justice.gov.uk>
-RUN  apk update && apk upgrade && apk add netcat-openbsd && apk add --update curl && rm -rf /var/cache/apk/*
 
-ENV NAME keyworker-service
-ENV JAR_PATH build/libs
-ARG VERSION
+RUN apk update \
+  && apk upgrade \
+  && apk add netcat-openbsd \
+  && apk add --update curl \
+  && rm -rf /var/cache/apk/*
 
 WORKDIR /app
 
-COPY ${JAR_PATH}/${NAME}*.jar /app
+COPY build/libs/keyworker-service*.jar /app/app.jar
 COPY run.sh /app
 
-RUN chmod a+x /app/run.sh
-ENTRYPOINT /app/run.sh
+ENTRYPOINT ["/bin/sh", "/app/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ RUN apk update \
   && apk add --update curl \
   && rm -rf /var/cache/apk/*
 
+# Install AWS RDS Root cert into Java truststore
+RUN mkdir /root/.postgresql \
+  && curl https://s3.amazonaws.com/rds-downloads/rds-ca-2015-root.pem \
+    > /root/.postgresql/root.crt
+
 WORKDIR /app
 
 COPY build/libs/keyworker-service*.jar /app/app.jar

--- a/run.sh
+++ b/run.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
-echo "********************************************************"
-echo "Starting Key-Worker Service                             "
-echo "********************************************************"
-NAME=${NAME:-keyworker-service}
-JAR=$(find . -name ${NAME}*.jar|head -1)
-java ${JAVA_OPTS} -Dcom.sun.management.jmxremote.local.only=false -Djava.security.egd=file:/dev/./urandom -jar "${JAR}"
-
+exec java ${JAVA_OPTS} \
+  -Dcom.sun.management.jmxremote.local.only=false \
+  -Djava.security.egd=file:/dev/./urandom \
+  -jar /app/app.jar


### PR DESCRIPTION
Split into a few commits:

* Use `exec` so that java is PID 1 and signals work for clean shutdown
* Cache gradle dependencies to speed up the CI build
* Make the container support SSL trust of RDS postgres